### PR TITLE
TII-189 Update Hibernate mappings

### DIFF
--- a/pack/src/webapp/WEB-INF/components.xml
+++ b/pack/src/webapp/WEB-INF/components.xml
@@ -88,7 +88,7 @@
 	<bean
 		id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.schedulerContentReviewQueue"
 		class="org.sakaiproject.component.app.scheduler.jobs.SpringStatefulJobBeanWrapper"
-		singleton="true" init-method="init">
+		init-method="init">
 		<property name="beanId">
 			<value>TiiContentReviewQueue</value>
 		</property>
@@ -112,7 +112,7 @@
 	<bean
 		id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.schedulerContentReviewReports"
 		class="org.sakaiproject.component.app.scheduler.jobs.SpringStatefulJobBeanWrapper"
-		singleton="true" init-method="init">
+		init-method="init">
 		<property name="beanId">
 			<value>TiiContentReviewReports</value>
 		</property>
@@ -136,7 +136,7 @@
     <bean
         id="org.sakaiproject.api.app.scheduler.JobBeanWrapper.schedulerContentReviewRosterSync"
         class="org.sakaiproject.component.app.scheduler.jobs.SpringStatefulJobBeanWrapper"
-        singleton="true" init-method="init">
+        init-method="init">
         <property name="beanId">
             <value>TiiContentReviewRosterSync</value>
         </property>


### PR DESCRIPTION
Update hibernate mappings by removing the "singleton" parameter.
This is necessary for the version of hibernate used in 11.0